### PR TITLE
Add normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ Normalization means two things for this algorithm: detone and upcase.
   GreekStemmer.stem("ΠΟΣΟΤΗΤΑ") # => "ΠΟΣΟΤΗΤ"
 ```
 
+If your input not ready to use, you can do normalizeing in one step
+
+```ruby
+  require 'greek_stemmer'
+
+  GreekStemmer.normalize_and_stem("ποσοτητα") # => "ΠΟΣΟΤΗΤ"
+```
+
 ## References
 
 * [Development of a Stemmer for the Greek Language](http://people.dsv.su.se/~hercules/papers/Ntais_greek_stemmer_thesis_final.pdf)

--- a/lib/greek_stemmer.rb
+++ b/lib/greek_stemmer.rb
@@ -21,6 +21,24 @@ module GreekStemmer
     end
   end
 
+  # Normalizeing
+  DIACRITICS_REMOVER_MAP = {
+    "Ά" => "Α", "ά" => "α", "Έ" => "Ε", "έ" => "ε", "Ή" => "Η", "ή" => "η",
+    "Ί" => "Ι", "Î" => "Ι", "ί" => "ι", "ϊ" => "ι", "ΐ" => "ι", "Ό" => "Ο",
+    "ό" => "ο", "ς" => "σ", "Ύ" => "Υ", "ύ" => "υ", "ϋ" => "υ", "ΰ" => "υ",
+    "Ώ" => "Ω", "ώ" => "ω"
+  }.freeze
+
+  # Normalize after stem
+  def normalize_and_stem(word)
+    stem(normalize(word))
+  end
+
+  # Normalize Greek words for be ready to stem
+  def normalize(word)
+    diacritics_remover(word).upcase
+  end
+
   # Protected words
   PROTECTED_WORDS   = load_settings("protected_words")
 
@@ -257,6 +275,14 @@ module GreekStemmer
   end
 
   private
+
+  def diacritics_remover(string)
+    string.gsub(diacritics_remover_map_keys, DIACRITICS_REMOVER_MAP)
+  end
+
+  def diacritics_remover_map_keys
+    Regexp.new(DIACRITICS_REMOVER_MAP.keys.map { |x| Regexp.escape(x) }.join("|"))
+  end
 
   # Top-level stemming exceptions for full words
   def step_0_exceptions

--- a/lib/greek_stemmer.rb
+++ b/lib/greek_stemmer.rb
@@ -36,7 +36,7 @@ module GreekStemmer
 
   # Normalize Greek words for be ready to stem
   def normalize(word)
-    diacritics_remover(word).upcase
+    remove_diacritics(word).upcase
   end
 
   # Protected words
@@ -276,7 +276,7 @@ module GreekStemmer
 
   private
 
-  def diacritics_remover(string)
+  def remove_diacritics(string)
     string.gsub(diacritics_remover_map_keys, DIACRITICS_REMOVER_MAP)
   end
 

--- a/lib/greek_stemmer/version.rb
+++ b/lib/greek_stemmer/version.rb
@@ -1,3 +1,3 @@
 module GreekStemmer
-  VERSION = "1.1.10"
+  VERSION = "1.2.0"
 end


### PR DESCRIPTION
With this PR I add a simple normalization process, so now with the stemmer you can call `normalize_and_stem` if your input not prepared as stemmer input. I'm thinking It's useful generally, or if you don't need it simple you still can use the `stem` call.